### PR TITLE
robotont_webapp added to bringup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,23 +7,29 @@ A package for maintaining bring-up and configuration files
 This package is used as a single entry point for starting background nodes on Robotont's on-board computer. The files are designed to be automatically launched from systemd services located in ```/lib/systemd/system/```. You  may also use the launchers in this package to manually bring up the nodes, however before doing so, make sure that Robotont's systemd services have been stopped.
 
 ### robotont\_bringup.launch
-* To use the full capability of the robot, run:
+
+To use the full capability of the robot, run:
 
 ```bash
 roslaunch robotont_support robotont_bringup.launch
 ```
-This command will start robotont driver along with the Realsense 3D camera driver, loads the robot description to the parameter server, and starts state publishers.
+This command will perform the following actions:
+* start the [robotont driver](https://github.com/robotont/robotont_driver)
+* start the [Realsense 3D camera driver](https://github.com/IntelRealSense/realsense-ros)
+* serve the robotont [web application](https://github.com/robotont/robotont_webapp)
+* load the [robot description](https://github.com/robotont/robotont_nuc_description) to the parameter server
+* start the state publishers.
 
 
-* If you do not need the Realsense camera, you can save the battery by running only the robot driver:
+You can control whether the Realsense camera and the web application are started with the following arguments:
 
 ```bash
-roslaunch robotont_support robotont_bringup.launch realsense:=false
+roslaunch robotont_support robotont_bringup.launch realsense:=false webapp:=false
 ```
 
 ### cam\_throttling.launch
 
-* This launch file uses throttling node from ```topic_tools``` package to create additional ```..._throttled``` depth camera topics with slowed down publishing rates. Throttling becomes useful when trying to transfer image/depth streams to a remote computer in limited bandwitdh conditions. Use the ```cam_fps``` argument to set the desired publishing rate for the throttled topics.
+This launch file uses throttling node from ```topic_tools``` package to create additional ```..._throttled``` depth camera topics with slowed down publishing rates. Throttling becomes useful when trying to transfer image/depth streams to a remote computer in limited bandwitdh conditions. Use the ```cam_fps``` argument to set the desired publishing rate for the throttled topics.
 
 ```bash
 roslaunch robotont_support cam_throttling.launch cam_fps:=5

--- a/launch/robotont_bringup.launch
+++ b/launch/robotont_bringup.launch
@@ -46,7 +46,7 @@
 
   <group if="$(arg webapp)">
     <include file="$(find robotont_webapp)/launch/webapp.launch">
-      <!--arg name="__ns" value="$(arg __ns)"/-->
+      <arg name="__ns" value="$(arg __ns)"/>
     </include>
   </group>
 

--- a/launch/robotont_bringup.launch
+++ b/launch/robotont_bringup.launch
@@ -8,6 +8,7 @@
   <env name="ROSCONSOLE_FORMAT" value="[${function}] ${message}" />
 
   <arg name="realsense" default="true" />
+  <arg name="webapp" default="true" />
   <arg name="__ns" default=""/>
   <arg name="eval_underscore_bypass" value="$(arg __ns)"/>
   <arg if="$(eval eval_underscore_bypass == '')" name="prefix" default=''/>
@@ -42,5 +43,11 @@
    <!-- State publishers -->
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
+
+  <group if="$(arg webapp)">
+    <include file="$(find robotont_webapp)/launch/webapp.launch">
+      <!--arg name="__ns" value="$(arg __ns)"/-->
+    </include>
+  </group>
 
 </launch>

--- a/package.xml
+++ b/package.xml
@@ -10,6 +10,7 @@
     <run_depend>robotont_driver</run_depend>
     <run_depend>robotont_description</run_depend>
     <run_depend>robotont_nuc_description</run_depend>
+    <run_depend>robotont_webapp</run_depend>
     <run_depend>realsense2_camera</run_depend>
     <run_depend>topic_tools</run_depend>
 </package>


### PR DESCRIPTION
I have added a few lines to support robotont_webapp in our bring-up sequence. The plan is to go live with this one once [it the PR ](https://github.com/robotont/robotont_webapp/pull/1) gets approved.